### PR TITLE
coerce datetime to date for date emitter

### DIFF
--- a/fluff/__init__.py
+++ b/fluff/__init__.py
@@ -42,6 +42,9 @@ class custom_date_emitter(base_emitter):
 
     def validate(self, value):
         assert value[0] is not None
+        assert isinstance(value[0], (datetime.date, datetime.datetime))
+        if isinstance(value[0], datetime.datetime):
+            value[0] = value[0].date()
 
 
 class custom_null_emitter(base_emitter):
@@ -52,7 +55,6 @@ class custom_null_emitter(base_emitter):
 
 date_emitter = custom_date_emitter()
 null_emitter = custom_null_emitter()
-
 
 
 def filter_by(fn):


### PR DESCRIPTION
The main purpose for doing this was so that there are less indicator grains which mean less data to store in SQL if using ctable.

If datetime is required we could add a datetime_emitter.
