### PR TITLE
Prepended doc_type to the key in map.js

### DIFF
--- a/fluff/_design/views/generic/map.js
+++ b/fluff/_design/views/generic/map.js
@@ -29,7 +29,7 @@ function (doc) {
                             for (i = 0; i < doc[calcName][emitterName].length; i++) {
                                 var value = doc[calcName][emitterName][i];
                                 if (typeOf(value) === 'object') {
-                                    var custom_key = value['group_by'] === null ? key : value['group_by'];
+                                    var custom_key = value['group_by'] === null ? key : [doc.doc_type].concat(value['group_by']);
                                     emit(custom_key.concat([calcName, emitterName, value['date']]), value['value']);
                                 } else {
                                     emit(key.concat([calcName, emitterName, value[0]]), value[1]);


### PR DESCRIPTION
@snopoke this might break some stuff.  `get_results()` expects the IndicatorDoc doc_type to be the first element in the key.  This PR updates the view to bring the Calculator group_by in line with the IndicatorDoc group_by.
