### PR TITLE
Flatfield

### DIFF
--- a/fluff/__init__.py
+++ b/fluff/__init__.py
@@ -239,7 +239,8 @@ class FlatField(schema.StringProperty):
     """
     This constructs a field for your indicator document that can perform basic
     operations on an item.  Pass in a function that accepts an item and returns
-    a dict.
+    a string.  This field is not a calculator, so it cannot be accessed with
+    get_results (yet).  Instead, access the fluff doc directly.
     Example:
 
         class MyFluff(fluff.IndicatorDocument):
@@ -254,9 +255,6 @@ class FlatField(schema.StringProperty):
 
     def calculate(self, item):
         return self.fn(item)
-
-    # def get_result(self, doc_id):
-        # return something
 
 
 class AttributeGetter(object):


### PR DESCRIPTION
Adds "a field for your indicator document that can perform basic operations on an item.  Pass in a function that accepts an item and returns a dict."  I welcome suggestions on the name if you've got something clearer.
Example:

```
    class MyFluff(fluff.IndicatorDocument):
        document_class = CommCareCase
        ...
        name = fluff.FlatField(lambda case: case.name) 
```

I've been using this for a little while for my custom report, it's time to solicit feedback and merge it in to master.
