### PR TITLE
save fluff documents directly to SQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install:
  - "sudo apt-get install libevent-dev"
  - "pip install -e ."
+ - "psql -c 'create database fluff_test' -U postgres"
  - "pip install coverage coveralls"
 script:
  - "coverage run setup.py test"

--- a/fluff/signals.py
+++ b/fluff/signals.py
@@ -1,3 +1,86 @@
+import pprint
+import sqlalchemy
+import logging
 from django.dispatch import Signal
+from django.conf import settings
+from itertools import chain
+from django.db.models import signals
+from pillowtop.utils import import_pillow_string
+from alembic.migration import MigrationContext
+from alembic.autogenerate import compare_metadata
+
+logger = logging.getLogger('fluff')
 
 indicator_document_updated = Signal(providing_args=["diff"])
+
+class RebuildTableException(Exception):
+    pass
+
+
+def catch_signal(app, **kwargs):
+    app_name = app.__name__.rsplit('.', 1)[0]
+    if app_name == 'fluff':
+        from fluff import FluffPillow
+
+        pillows = list(chain.from_iterable(settings.PILLOWTOPS.values()))
+        for pillow_string in pillows:
+            pillow_class = import_pillow_string(pillow_string, instantiate=False)
+            if issubclass(pillow_class, FluffPillow):
+                doc_class = pillow_class.indicator_class
+                create_update_indicator_table(doc_class, pillow_class)
+
+
+def create_update_indicator_table(doc_class, pillow_class):
+    doc = doc_class()
+    if doc.save_direct_to_sql:
+        try:
+            check_table(doc)
+        except RebuildTableException:
+            rebuild_table(pillow_class, doc)
+
+
+def check_table(indicator_doc):
+    def check_diff(diff):
+        if diff[0] in ('add_table', 'remove_table'):
+            if diff[1].name == table_name:
+                raise RebuildTableException()
+        elif diff[2] == table_name:
+            raise RebuildTableException()
+
+    table_name = indicator_doc._table.name
+    diffs = compare_metadata(get_migration_context(), indicator_doc._table.metadata)
+    for diff in diffs:
+        if isinstance(diff, list):
+            for d in diff:
+                check_diff(d)
+        else:
+            check_diff(diff)
+
+
+def rebuild_table(pillow_class, indicator_doc):
+    logger.warn('Rebuilding table and resetting checkpoint for %s', pillow_class)
+    table = indicator_doc._table
+    with get_engine().begin() as connection:
+            table.drop(connection, checkfirst=True)
+            table.create(connection)
+            owner = getattr(settings, 'SQL_REPORTING_OBJECT_OWNER', None)
+            if owner:
+                connection.execute('ALTER TABLE "%s" OWNER TO %s' % (table.name, owner))
+    if pillow_class:
+        pillow_class().reset_checkpoint()
+
+
+def get_migration_context():
+    if not hasattr(get_migration_context, '_mc') or get_migration_context._mc is None:
+        get_migration_context._mc = MigrationContext.configure(get_engine().connect())
+    return get_migration_context._mc
+
+
+def get_engine():
+    if not hasattr(get_engine, '_engine') or get_engine._engine is None:
+        get_engine._engine = sqlalchemy.create_engine(settings.SQL_REPORTING_DATABASE_URL)
+    return get_engine._engine
+
+
+signals.post_syncdb.connect(catch_signal)
+

--- a/fluff/util.py
+++ b/fluff/util.py
@@ -1,0 +1,69 @@
+# -*- coding: UTF-8 -*-
+
+import logging
+import datetime
+import sqlalchemy
+logger = logging.getLogger('fluff')
+
+metadata = sqlalchemy.MetaData()
+
+
+def get_indicator_model(name, indicator_doc):
+    columns = [
+        sqlalchemy.Column(
+            'doc_id',
+            sqlalchemy.Unicode(255),
+            nullable=False,
+            primary_key=True),
+        sqlalchemy.Column(
+            'date',
+            sqlalchemy.Date,
+            nullable=False,
+            primary_key=True),
+    ]
+
+    group_types = indicator_doc.get_group_types()
+    for group_name in indicator_doc.get_group_names():
+        columns.append(sqlalchemy.Column(
+            group_name,
+            get_column_type(group_types[group_name]),
+            nullable=False,
+            primary_key=True
+        ))
+
+    calculators = indicator_doc._calculators
+    for calc_name in sorted(calculators.keys()):
+        for emitter_name in calculators[calc_name]._fluff_emitters:
+            col_name = '{0}_{1}'.format(calc_name, emitter_name)
+            columns.append(sqlalchemy.Column(
+                col_name,
+                sqlalchemy.Integer,
+                nullable=True,
+            ))
+
+    return sqlalchemy.Table('fluff_{0}'.format(name), metadata, *columns)
+
+
+def get_column_type(data_type):
+    from fluff import TYPE_DATE, TYPE_INTEGER, TYPE_STRING
+    if data_type == TYPE_DATE:
+        return sqlalchemy.Date
+    if data_type == TYPE_INTEGER:
+        return sqlalchemy.Integer
+    if data_type == TYPE_STRING:
+        return sqlalchemy.Unicode(255)
+
+    raise Exception('Enexpected type: {0}'.format(data_type))
+
+
+def default_null_value_placeholder(data_type):
+    if data_type == "string":
+        return '__none__'
+    elif data_type == "integer":
+        return 1618033988  # see http://en.wikipedia.org/wiki/Golden_ratio
+    elif data_type == "date":
+        return datetime.date.min
+    elif data_type == 'datetime':
+        return datetime.datetime.min
+    else:
+        raise Exception("Unexpected type", data_type)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,10 @@ Django==1.3.1
 jsonobject-couchdbkit==0.6.5.2
 pytz==2013b
 six==1.3.0
+SQLAlchemy==0.8.2
+alembic==0.6.0
 unittest2==0.5.1
+psycopg2>=2.4.1
 -e git+git://github.com/dimagi/fakecouch.git#egg=fakecouch
 -e git+git://github.com/dimagi/pillowtop.git#egg=pillowtop
 -e git+git://github.com/dimagi/dimagi-utils.git#egg=dimagi-utils

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,13 @@ setup(
         'pillowtop>=0.1.4',
         'dimagi-utils>=1.0.2',
         'pytz',
+        'SQLAlchemy==0.8.2',
+        'alembic==0.6.0'
     ],
     tests_require=[
         'django',
         'unittest2',
-        'fakecouch>=0.0.3'
+        'fakecouch>=0.0.3',
+        'psycopg2>=2.4.1',
     ]
 )


### PR DESCRIPTION
Gives you the option of saving fluff data directly to SQL (bypassing couchdb altogether). Table structure is compatible with existing `ctable` tables (besides table name change and one additional column).

Enabled by setting `save_direct_to_sql=True` in Fluff indicator doc:

```
class MyIndicators(fluff.IndicatorDocument):
    save_direct_to_sql = True
    ....
```
