### PR TITLE
delete rows for docs before updateing

### DIFF
--- a/fluff/__init__.py
+++ b/fluff/__init__.py
@@ -588,12 +588,17 @@ class IndicatorDocument(schema.Document):
         names = ['doc_id'] + self.get_group_names() + ['date']
         connection = engine.connect()
         try:
+            # delete all existing rows for this doc to ensure we aren't left with stale data
+            delete = self._table.delete(self._table.c.doc_id == self.id)
+            connection.execute(delete)
+
             for key, columns in rows.items():
                 key_columns = dict(zip(names, key))
                 for name, value in key_columns.items():
                     if value is None:
                         key_columns[name] = util.default_null_value_placeholder(types[name])
                 all_columns = dict(key_columns.items() + columns.items())
+
                 try:
                     insert = self._table.insert().values(**all_columns)
                     connection.execute(insert)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -464,7 +464,6 @@ class Test(TestCase):
         expected = [
             (u'123', date(1, 1, 1), u'mock', u'test_owner', None, None, None, None, None, 2, None, 1),
             (u'123', date(2013, 1, 1), u'abc', u'123', None, None, 2, None, 1, None, None, None),
-            (u'123', date(2012, 9, 24), u'mock', u'test_owner', 3, None, None, None, None, None, 1, None),
             (u'123', date(2012, 9, 23), u'mock', u'test_owner', 5, None, None, None, None, None, 1, None),
             (u'123', date(1, 1, 1), u'abc', u'xyz', None, None, None, 1, None, None, None, None),
             (u'123', date(2013, 1, 1), u'abc', u'xyz', None, 3, None, None, None, None, None, None),


### PR DESCRIPTION
This is to cater for cases where data is deleted / removed. An example would be a pillow that outputs one row for each form that was filled out against each case. If one of the forms was archived then the row for that form would remain.
