### PR TITLE
Switch Fluff reindexer to use by_domain_doc_type_date

### DIFF
--- a/fluff/management/commands/ptop_fast_reindex_fluff.py
+++ b/fluff/management/commands/ptop_fast_reindex_fluff.py
@@ -12,7 +12,7 @@ POOL_SIZE = 15
 class FluffPtopReindexer(PtopReindexer):
     help = "Fast reindex of fluff docs"
 
-    view_name = 'by_domain_doc_type/view'
+    view_name = 'by_domain_doc_type_date/view'
 
     # override these
     domain = None
@@ -31,7 +31,8 @@ class FluffPtopReindexer(PtopReindexer):
 
     def get_extra_view_kwargs(self):
         return {
-            'key': [self.domain, self.doc_class.__name__],
+            'startkey': [self.domain, self.doc_class.__name__],
+            'endkey': [self.domain, self.doc_class.__name__, {}],
         }
 
     def handle(self, *args, **options):

--- a/fluff/management/commands/ptop_fast_reindex_fluff.py
+++ b/fluff/management/commands/ptop_fast_reindex_fluff.py
@@ -12,7 +12,7 @@ POOL_SIZE = 15
 class FluffPtopReindexer(PtopReindexer):
     help = "Fast reindex of fluff docs"
 
-    view_name = 'domain/docs'
+    view_name = 'by_domain_doc_type/view'
 
     # override these
     domain = None
@@ -31,8 +31,7 @@ class FluffPtopReindexer(PtopReindexer):
 
     def get_extra_view_kwargs(self):
         return {
-            'startkey': [self.domain, self.doc_class.__name__],
-            'endkey': [self.domain, self.doc_class.__name__, {}],
+            'key': [self.domain, self.doc_class.__name__],
         }
 
     def handle(self, *args, **options):


### PR DESCRIPTION
I tested this out locally with the OpmUserFluffPillow, and both versions had consistent results.

Depends on (and should be merged with https://github.com/dimagi/commcare-hq/pull/9137)

@dannyroberts @millerdev cc @nickpell