### PR TITLE
assume if metadata is set then domain is set properly

### DIFF
--- a/fluff/pillow.py
+++ b/fluff/pillow.py
@@ -50,7 +50,7 @@ class FluffPillow(PythonPillow):
             return self._is_doc_type_match(doc_type) or self._is_doc_type_deleted_match(doc_type)
 
         # if metadata.domain is specified this should never have to get the document out of the DB
-        domain = (change.metadata and change.metadata.domain) or change.get_document().get('domain')
+        domain = change.metadata.domain if change.metadata else change.get_document().get('domain')
         if domain_filter(domain):
             # same for metadata.document_type
             doc_type = (change.metadata and change.metadata.document_type) or change.get_document().get('doc_type')
@@ -75,7 +75,6 @@ class FluffPillow(PythonPillow):
 
     def change_transform(self, doc_dict):
         delete = False
-
         doc = self.wrapper.wrap(doc_dict)
         doc = ReadOnlyObject(doc)
 


### PR DESCRIPTION
this makes a big difference since you don't have to go back to couch for anything in the meta feed that doesn't have a domain at all.